### PR TITLE
metrics: VMs: disable apt-daily services

### DIFF
--- a/VMs/metrics/ubuntu16.04/user-data
+++ b/VMs/metrics/ubuntu16.04/user-data
@@ -51,6 +51,13 @@ runcmd:
 #   take - that is, it injects noise into our test system.
  - apt remove -y unattended-upgrades
 
+# Also disable the apt daily service so it does not invoke any polls that may take
+# the apt-lock
+ - systemctl mask apt-daily.service
+ - systemctl mask apt-daily.timer
+ - systemctl mask apt-daily-upgrade.service
+ - systemctl mask apt-daily-upgrade.timer
+
 # Cleanup
  - apt-get auto-remove -y
 

--- a/VMs/metrics/ubuntu16.04/user-data.proxy
+++ b/VMs/metrics/ubuntu16.04/user-data.proxy
@@ -55,6 +55,13 @@ runcmd:
 #   take - that is, it injects noise into our test system.
  - apt remove -y unattended-upgrades
 
+# Also disable the apt daily service so it does not invoke any polls that may take
+# the apt-lock
+ - systemctl mask apt-daily.service
+ - systemctl mask apt-daily.timer
+ - systemctl mask apt-daily-upgrade.service
+ - systemctl mask apt-daily-upgrade.timer
+
 # Cleanup
  - apt-get auto-remove -y
 


### PR DESCRIPTION
The apt-daily[-upgrade] services are invoked at boot.
They are suspects in taking the apt-lock, which causes
the CI scripts to fail (during apt operations, as the
lock is already then held). Disable them permanently by
masking them off.

Fixes: #50

Signed-off-by: Graham Whaley <graham.whaley@intel.com>