### PR TITLE
VMs: metrics: update README and add helper scripts

### DIFF
--- a/VMs/metrics/6_start_clone_agent.sh
+++ b/VMs/metrics/6_start_clone_agent.sh
@@ -7,7 +7,7 @@ JARSRC="${HOME}/bin/agent.jar"
 JARDEST_DIR="/var/lib/jenkins"
 JARDEST="${JARDEST_DIR}/agent.jar"
 
-LOGFILE=/dev/null
+LOGFILE="${LOGFILE:-/dev/null}"
 
 source global_env.sh
 source lib.sh

--- a/VMs/metrics/jenkins_start.sh
+++ b/VMs/metrics/jenkins_start.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+ROOTDIR=${HOME}/kata-containers-ci/VMs/metrics
+# Ensure virsh can see the correct domain for our VMs.
+# On some systems a Jenkins ssh connection will connect to
+# qemu:///session by default, and thus will fail to clone/run
+# a new VM.
+export LIBVIRT_DEFAULT_URI=qemu:///system
+
+if [ $# -ne 1 ]; then
+	echo "Require VM config name as only parameter"
+	exit 1
+fi
+
+cd ${ROOTDIR}
+./6_start_clone_agent.sh $1
+
+echo "Done $0"

--- a/VMs/metrics/jenkins_stop.sh
+++ b/VMs/metrics/jenkins_stop.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+ROOTDIR=${HOME}/kata-containers-ci/VMs/metrics
+# Ensure virsh can see the correct domain for our VMs.
+# On some systems a Jenkins ssh connection will connect to
+# qemu:///session by default, and thus will fail to clone/run
+# a new VM.
+export LIBVIRT_DEFAULT_URI=qemu:///system
+
+echo "In $0"
+
+if [ $# -ne 1 ]; then
+	echo "Require VM config name as only parameter"
+	exit 1
+fi
+
+cd ${ROOTDIR}
+./7_delete_clone.sh $1
+
+echo "Done $0"
+


### PR DESCRIPTION
There were some useful details we did not have in the README, such as prereqs and
how to set up the user on the slave machine.
Also add a couple of jenkins helper scripts for launching from the jenkins SSH slave plugin.