### PR TITLE
VMs: metrics: enable perf inside VM

### DIFF
--- a/VMs/metrics/2_build_baseimage.sh
+++ b/VMs/metrics/2_build_baseimage.sh
@@ -122,7 +122,7 @@ run_cloud_init() {
  	--description "simple test" \
  	--os-type=${VM_TYPE} \
  	--os-variant=${VM_VARIANT} \
- 	--cpu=host \
+ 	--cpu=host-passthrough \
  	--ram=${VM_RAM_SIZE} \
  	--vcpus=${VM_VCPUS} \
  	--disk path=${IMG_NAME},bus=virtio,size=${VM_IMAGE_SIZE} \

--- a/VMs/metrics/2_build_baseimage.sh
+++ b/VMs/metrics/2_build_baseimage.sh
@@ -46,7 +46,7 @@ check_keys() {
 
 	PUBLICKEYCONTENTS=$(cat ${PUBKEYNAME})
 	# Escape any special regex chars in the key for later use with sed
-        ESCAPEDPUBLICKEYCONTENTS=$(echo "${PUBLICKEYCONTENTS}" | sed -e 's/\([[\/.*]\|\]\)/\\&/g')
+	ESCAPEDPUBLICKEYCONTENTS=$(echo "${PUBLICKEYCONTENTS}" | sed -e 's/\([[\/.*]\|\]\)/\\&/g')
 }
 
 create_initfiles() {
@@ -118,19 +118,19 @@ run_cloud_init() {
 	# add the existing simple qcow2 image file to virsh
 	message "Creating VM master image"
 	virt-install \
- 	-n ${VM_NAME} \
- 	--description "simple test" \
- 	--os-type=${VM_TYPE} \
- 	--os-variant=${VM_VARIANT} \
- 	--cpu=host-passthrough \
- 	--ram=${VM_RAM_SIZE} \
- 	--vcpus=${VM_VCPUS} \
- 	--disk path=${IMG_NAME},bus=virtio,size=${VM_IMAGE_SIZE} \
- 	--disk path=${ISOFILENAME},device=cdrom \
- 	--graphics none \
- 	--console pty,target_type=serial \
- 	--import \
- 	--boot useserial=on
+	-n ${VM_NAME} \
+	--description "simple test" \
+	--os-type=${VM_TYPE} \
+	--os-variant=${VM_VARIANT} \
+	--cpu=host-passthrough \
+	--ram=${VM_RAM_SIZE} \
+	--vcpus=${VM_VCPUS} \
+	--disk path=${IMG_NAME},bus=virtio,size=${VM_IMAGE_SIZE} \
+	--disk path=${ISOFILENAME},device=cdrom \
+	--graphics none \
+	--console pty,target_type=serial \
+	--import \
+	--boot useserial=on
 }
 
 main() {

--- a/VMs/metrics/ubuntu16.04/user-data
+++ b/VMs/metrics/ubuntu16.04/user-data
@@ -21,6 +21,7 @@ packages:
  - gcc
  - git
  - jq
+ - linux-tools-common
  - make
 
 runcmd:
@@ -42,6 +43,7 @@ runcmd:
  - sudo add-apt-repository "deb [arch=ARCH] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
  - apt-get update
  - apt-get install -y docker-ce
+ - apt-get install -y linux-tools-`uname -r`
  - gpasswd -a USERNAME docker
 
 # Remove the unattended upgrade feature, for two reasons:


### PR DESCRIPTION
Some of our metrics tests use `perf` to gather data. Enable that both at the VM level
and with the tooling inside the VM.