### PR TITLE
deployment: packet.net ansible scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ jenkins/credentials.xml
 # Include the pictures
 !pictures
 !pictures/**
+
+# Include the deployment files
+!deployment
+!deployment/**

--- a/deployment/packet/README.md
+++ b/deployment/packet/README.md
@@ -1,0 +1,168 @@
+# Kata Containers Jenkins CI slave deployment scripts
+
+This directory contains a set of [Ansible](https://docs.ansible.com/) scripts to help
+deploy Kata metrics CI build slaves on the [packet.net](https://www.packet.com/) cloud.
+
+These scripts help:
+- Create a new bare metal machine instance in the packet.net cloud
+- Configure an instance with the components necessary to be able to run both:
+  - The [Kata metrics CI VMs](https://github.com/kata-containers/ci/tree/master/VMs/metrics)
+    as per the [Pre-requisites](https://github.com/kata-containers/ci/tree/master/VMs/metrics#pre-requisites) listed on that page.
+  - The instances as bare metal Jenkins CI slaves.
+- Provide a helper to delete existing instances.
+
+## Pre-requisites
+
+In order to execute these scripts you will need a few pre-requisites installed and
+configured on your host system:
+
+- `Ansible` (version >= v2.3).
+- `packet-python` - see [the Ansible guide](https://docs.ansible.com/ansible/latest/scenario_guides/guide_packet.html) for details.
+- A Kata Containers packet.net project [token](https://www.packet.com/developers/api/).
+- The Kata Containers packet.net root user SSH private key pair.
+- The Kata Containers packet.net Jenkins user SSH private key pair.
+- A copy of the required golang version Linux [tarball](https://golang.org/dl/)
+
+## Local setup
+
+- Export your packet.net token into your environment, as detailed on the Ansible packet [documentation page](https://docs.ansible.com/ansible/latest/scenario_guides/guide_packet.html#requirements)
+- Place your packet.net root user SSH keys into your `${HOME}/.ssh` directory, ready for ansible to use later (expected name is `packet_rsa[.pub]`)
+- Place your packet.net jenksin user SSH keys into your `${HOME}/.ssh` directory, ready to test later (expected name `kata-metric1[.pub]`)
+- Download a copy of the golang install tarball into this directory.
+
+## Creating an instance
+
+To create an instance, check the following settings in the `install_packet.yaml` file match
+your required system:
+
+- hostnames
+- operating_system
+- plan
+- facility
+
+The `project_id` field should already be configured for the correct project. You should have
+already set the correct `PACKET_API_TOKEN` in your environment.
+
+Run the Following command. All phases should pass, and you should have no failures
+reported:
+
+```bash
+$ ansible-playbook create_packet.yaml
+```
+
+This will deploy a new instance on packet.net, and wait for it to finish booting.
+The script will print out the machine details. Save these for later, as you will require
+the public IP address the instance has been allocated. You can also find the IP address
+of the instance on the packet.net web interface.
+
+## Configuring an instance
+
+The instance now needs to be configured and have the correct packages and users installed
+before it can be used for Kata Containers metrics CI.
+
+Ansible achieves this by SSH'ing into the system as the `root` user to run the relevant
+configuration commands. Before executing the installation script, the root user SSH keys
+need to be configured and tested.
+
+Using the public IP address recorded in the deployment phase above, configure your
+`${HOME}/.ssh/config` file similar to below, replacing the `AAA.BBB.CCC.DDD` with the
+relevant IP address:
+
+```bash
+# packet c1small-test
+host AAA.BBB.CCC.DDD
+ ServerAliveInterval 30
+ User root
+ IdentityFile ~/.ssh/packet_rsa
+ IdentitiesOnly yes
+```
+
+Test this configuration such as:
+
+```bash
+$ ssh root@AAA.BBB.CCC.DDD
+```
+
+If the configuration is correct, you should be logged into the packet.net instance.
+Your system may ask to add the instance key to your `known_hosts` file, which may
+be necessary to perform the next step. Now exit the `ssh` session.
+
+You also need to configure Ansible to recognise the new instance as a valid host. This can
+be done with some local configuaration files.
+
+Create an `ansible.cfg` file in the current directory, with the following contents, whilst
+substituding the `<path to this directory>` with the full path to where these files are
+located on your system:
+
+```
+[defaults]
+
+inventory = <path to this directory>/ansible_hosts
+```
+
+Create an 'ansible_hosts' file on in this directory, with the contents:
+
+```
+AAA.BBB.CCC.DDD
+```
+
+replacing `AAA.BBB.CCC.DDD` with the IP address of the instance obtained during creation.
+
+To configure the instance, edit the `install_packet.yaml` file and change the `hosts:`
+line to reflect the AAA.BBB.CCC.DDD IP address obtained during instance creation.
+
+Save this change, then execute the following:
+
+```bash
+$ ansible-playbook install_packet.yaml
+```
+
+All steps should pass successfully, and Ansible should report no failures.
+Your instance should now be configured to execute Jenkins CI tasks either on the
+'bare metal', or inside a Metrics VM.
+
+## Testing the instance
+
+Now the instance is deployed and configured, we can test that the jenkins user is set up
+correctly. Add the jenkins user SSH key into your .ssh configuration:
+
+```bash
+# packet c1small-test jenkins user
+host AAA.BBB.CCC.DDD
+ ServerAliveInterval 30
+ User jenkins
+ IdentityFile ~/.ssh/kata-metric1
+ IdentitiesOnly yes
+```
+
+Test the configuration:
+
+```bash
+$ ssh jenkins@AAA.BBB.CCC.DDD
+```
+
+This should log you into the instance as the `jenkins` user.
+
+## Installing the Metrics VMs
+
+If you are intending to use the metrics VMs, remain logged in as the jenkins user.
+Execute the following to set the final necessary environment setting:
+
+```bash
+$ export PATH=/usr/local/go/bin:$PATH
+```
+
+and follow the instructions on the [metrics VMs](https://github.com/kata-containers/ci/tree/master/VMs/metrics#example)
+page to complete the installation ready to deploy the instance into the CI Jenkins master.
+
+
+## Integration into the Jenkins master
+
+The slave instance can now be integrated into the Jenkins master as a build machine. Details
+can be found [in this document](https://github.com/kata-containers/ci/blob/master/Jenkins_setup.md)
+
+## Deleting an instance
+
+The `delete_packet.yaml` Ansible script is provided as a helper in case an existing
+packet.net instance needs to be removed. These can also be removed using the packet.net
+web interface.

--- a/deployment/packet/create_packet.yaml
+++ b/deployment/packet/create_packet.yaml
@@ -1,0 +1,23 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+- name: create t1.small device and wait up to 10 minutes for active state
+  hosts: localhost
+  tasks:
+  - packet_device:
+      project_id: e8e311a5-0dbb-4342-bafd-840ff074003e
+      hostnames: t1small-test
+      operating_system: ubuntu_16_04
+      plan: t1.small.x86
+      facility: sjc1
+      state: active
+      wait_timeout: 600
+    register: newhost
+
+  - name: Print details
+    debug:
+      msg: "Machine details are: {{ newhost }}"
+

--- a/deployment/packet/delete_packet.yaml
+++ b/deployment/packet/delete_packet.yaml
@@ -1,0 +1,16 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+- name: delete t1.small device and wait up to 10 minutes for absent state
+  hosts: localhost
+  tasks:
+  - packet_device:
+      project_id: e8e311a5-0dbb-4342-bafd-840ff074003e
+      hostnames: t1small-test
+      facility: sjc1
+      state: absent
+      wait_timeout: 600
+

--- a/deployment/packet/env.yaml
+++ b/deployment/packet/env.yaml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Variables that are needed for the deployment scripts
+
+ourenv:
+  jenkins_sshkeypath: "~/.ssh/kata-metric1.pub"

--- a/deployment/packet/install_packet.yaml
+++ b/deployment/packet/install_packet.yaml
@@ -1,0 +1,118 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install an instance with enough elements to allow both CI operation
+# modes of:
+# - Jenkins to run a kata CI on the bare metal
+# - A Kata metrics CI VM to be installed/configured for isolation of the
+#   metrics runs
+#
+
+- name: Install base elements for Kata Metrics VMs
+  hosts: AAA.BBB.CCC.DDD
+  gather_facts: False
+  vars_files:
+    - env.yaml
+
+  tasks:
+    - name: Check for Jenkins SSH keyfile
+      stat:
+        path: "{{ ourenv.jenkins_sshkeypath }}"
+      register: ssh_key_stat
+      delegate_to: localhost
+
+    - name: Abort if no SSH keyfile
+      fail:
+        msg: "SSH keyfile not found in path {{ ourenv.jenkins_sshkeypath }} - aborting"
+      when: ssh_key_stat.stat.exists == false
+
+    - name: Update the apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install libvirt
+      package:
+        name: libvirt-bin
+        state: present
+
+    - name: Install qemu-kvm
+      package:
+        name: qemu-kvm
+        state: present
+
+    - name: Install virtinst
+      package:
+        name: virtinst
+        state: present
+
+    - name: Install genisoimage
+      package:
+        name: genisoimage
+        state: present
+
+    - name: Install default JRE
+      package:
+        name: default-jre
+        state: present
+
+    - name: Install git
+      package:
+        name: git
+        state: present
+
+    - name: Install snapd
+      package:
+        name: snapd
+        state: present
+
+    - name: Install yq
+      command: "snap install yq"
+
+    - name: Create golang dest dir
+      file:
+        path: /usr/local/go
+        state: directory
+
+    - name: Install golang
+      unarchive:
+        src: go1.10.2.linux-amd64.tar.gz
+        dest: /usr/local
+
+    - name: Set golang in PATH
+      copy:
+        dest: /etc/profile.d/custom-path.sh
+        content: 'PATH=/usr/local/go/bin:$PATH'
+
+    - name: Create the wheel group
+      group:
+        name: wheel
+        state: present
+
+    - name: Allow 'wheel' group to have passwordless sudo
+      lineinfile:
+        dest: /etc/sudoers
+        state: present
+        regexp: '^%wheel'
+        line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+        validate: visudo -cf %s
+
+    # We create the docker group now so we can add the Jenkins user to it,
+    # even though we won't have docker installed until later
+    - name: Create the docker group
+      group:
+        name: docker
+        state: present
+
+    - name: Create Jenkins user
+      user:
+        name: jenkins
+        groups: kvm,libvirtd,wheel,docker
+        append: true
+
+    - name: Setup Jenkins user SSH key
+      authorized_key:
+        user: jenkins
+        state: present
+        key: "{{ lookup('file', ourenv.jenkins_sshkeypath) }}"


### PR DESCRIPTION
Add a set of Ansible scripts to make packet.net machine deployment
easier and repeatable for Kata CI machines.