### PR TITLE
metrics: Add perf and disable unattended-upgrades to Ansible

### DIFF
--- a/deployment/packet/install_packet.yaml
+++ b/deployment/packet/install_packet.yaml
@@ -62,6 +62,20 @@
         name: git
         state: present
 
+    - name: Install linux-tools-common
+      package:
+        name: linux-tools-common
+        state: present
+
+    - name: Get Kernel version
+      shell: uname -r
+      register: kernel_version
+
+    - name: Install linux-tools-common specific kernel
+      package:
+        name: linux-tools-{{ kernel_version.stdout }}
+        state: present
+
     - name: Install snapd
       package:
         name: snapd
@@ -79,6 +93,11 @@
       unarchive:
         src: go1.10.2.linux-amd64.tar.gz
         dest: /usr/local
+
+    - name: Remove the unattended upgrade features
+      apt:
+        name: unattended-upgrades
+        state: absent
 
     - name: Set golang in PATH
       copy:


### PR DESCRIPTION
Perf package should be added so we can run the cpu network tests. We
also need to remove the unattended-upgrades.

Fixes #81

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>