### PR TITLE
deployment: packet: add script to copy over checkmetrics

### DIFF
--- a/deployment/packet/README.md
+++ b/deployment/packet/README.md
@@ -155,6 +155,23 @@ $ export PATH=/usr/local/go/bin:$PATH
 and follow the instructions on the [metrics VMs](https://github.com/kata-containers/ci/tree/master/VMs/metrics#example)
 page to complete the installation ready to deploy the instance into the CI Jenkins master.
 
+## Configuring checkmetrics
+
+A metrics machine must have a valid `checkmetrics` configuration file in `/etc/checkmetrics`
+in order to verify the metrics CI results.
+
+To aid setup of this file on the bare metal metrics slaves, the `add_checkmetrics.yaml`
+ansible script can be used. A local checkmetrics toml file must be present in the same
+directory where you execute the script, with the name form `checkmetrics-json-<uname>.toml`,
+where `<uname>` is the name of the remote slave, as set in `create_packet.yaml`, and returned
+by `uname -n` on that slave.
+
+To copy the toml file to the slave, edit the `add_checkmetrics.yaml` file, replacing
+`AAA.BBB.CCC.DDD` with the IP address of the instance. Then execute the following:
+
+```bash
+$ ansible-playbook add_checkmetrics.yaml
+```
 
 ## Integration into the Jenkins master
 

--- a/deployment/packet/add_checkmetrics.yaml
+++ b/deployment/packet/add_checkmetrics.yaml
@@ -1,0 +1,36 @@
+---
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install the /etc/checkmetrics/checkmetrics-json-<uname>.toml file into
+# the instance.
+#
+
+- name: Install checkmetrics toml file for Kata Metrics
+  hosts: AAA.BBB.CCC.DDD
+  vars_files:
+    - env.yaml
+
+  tasks:
+    - name: Check for local checkmetrics file
+      stat:
+        path: "./checkmetrics-json-{{ ansible_hostname }}.toml"
+      register: toml_stat
+      delegate_to: localhost
+
+    - name: Abort if no checkmetrics keyfile
+      fail:
+        msg: "checkmetrics toml file not found in path ./checkmetrics-json-{{ ansible_hostname }}.toml - aborting"
+      when: toml_stat.stat.exists == false
+
+    - name: Create checkmetrics dest dir
+      file:
+        path: /etc/checkmetrics
+        state: directory
+
+    - name: Copy over checkmetrics file
+      copy:
+        dest: /etc/checkmetrics/
+        src: "./checkmetrics-json-{{ ansible_hostname }}.toml"
+


### PR DESCRIPTION
For a metrics slave to correctly run, it requires a correctly
named checkmetrics.toml file placed in the right directory.
Add an ansible helper script to copy this file over.

Fixes: #88

Signed-off-by: Graham Whaley <graham.whaley@intel.com>