### PR TITLE
deployment: packet: add killall via psmisc package

### DIFF
--- a/deployment/packet/install_packet.yaml
+++ b/deployment/packet/install_packet.yaml
@@ -62,6 +62,11 @@
         name: git
         state: present
 
+    - name: Install psmisc
+      package:
+        name: psmisc
+        state: present
+
     - name: Install linux-tools-common
       package:
         name: linux-tools-common


### PR DESCRIPTION
Our scripts use `killall` sometimes during the cleanup
phase - add it via the `psmisc` package.

Fixes: #90

Signed-off-by: Graham Whaley <graham.whaley@intel.com>