### PR TITLE
README: Add link to CI status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This repository stores configuration for the Kata Containers Continuous Integrat
 
 The default CI system for Kata Containers is [Jenkins](https://jenkins.io/). See
 the [Jenkins Setup](Jenkins_setup.md) document for more details.
+
+# CI health status
+
+You can check for any known CI system issues [via this link](http://jenkins.katacontainers.io/view/CI%20Status/).


### PR DESCRIPTION
Add a link out to the CI status page so it can be more easily found.

Fixes: #107

Signed-off-by: Graham Whaley <graham.whaley@intel.com>