### PR TITLE
packet.net: disable background timers

### DIFF
--- a/deployment/packet/install_packet.yaml
+++ b/deployment/packet/install_packet.yaml
@@ -104,6 +104,26 @@
         name: unattended-upgrades
         state: absent
 
+    # We really don't want things happening in the background whilst
+    # we try to take stable measurements.
+    - name: Mask apt-daily.timer
+      systemd:
+        name: apt-daily.timer
+        state: stopped
+        enabled: false
+
+    - name: Mask apt-daily-upgrade.timer
+      systemd:
+        name: apt-daily-upgrade.timer
+        state: stopped
+        enabled: false
+
+    - name: Mask systemd-tmpfiles-clean.timer
+      systemd:
+        name: systemd-tmpfiles-clean.timer
+        state: stopped
+        enabled: false
+
     - name: Set golang in PATH
       copy:
         dest: /etc/profile.d/custom-path.sh


### PR DESCRIPTION
We don't want anything sporadically running in the background
on the machine in case they disrupt our test results.

Disable all the timers present in the default install.

Fixes: #121

Signed-off-by: Graham Whaley <graham.whaley@intel.com>