### PR TITLE
Add CI scripts

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
+export tests_repo_dir="$GOPATH/src/$tests_repo"
+
+clone_tests_repo()
+{
+	# KATA_CI_NO_NETWORK is (has to be) ignored if there is
+	# no existing clone.
+	if [ -d "$tests_repo_dir" -a -n "$KATA_CI_NO_NETWORK" ]
+	then
+		return
+	fi
+
+	go get -d -u "$tests_repo" || true
+}
+
+run_static_checks()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/ci"
+}

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+# No explicit tests currently
+true

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+clone_tests_repo
+
+pushd "${tests_repo_dir}"
+.ci/setup.sh
+popd

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_static_checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+dist: xenial
+
+language: go
+
+go:
+  - master
+
+before_install:
+  - ".ci/setup.sh"
+
+before_script:
+  - ".ci/static-checks.sh"
+
+script:
+  - ".ci/run.sh"


### PR DESCRIPTION
Add a basic set of CI scripts so that static analysis checks are performed on PRs in this repo.

Also, add a Travis configuration file. Note that language is set to `go` so that `golang` will be installed automatically (since it is required by the `.ci/*` scripts).

Fixes: #197.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
