### PR TITLE
jenkins: Add jenkins job for KSM, pentesting, and popular docker images

### DIFF
--- a/jenkins/jobs/kata-containers-tests-ubuntu-18-04-master-ksm-pentest-popular-images/config.xml
+++ b/jenkins/jobs/kata-containers-tests-ubuntu-18-04-master-ksm-pentest-popular-images/config.xml
@@ -1,9 +1,10 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description>Runs the popular docker images script</description>
+  <description>Runs the ksm, pentest and popular images tests</description>
   <keepDependencies>false</keepDependencies>
   <properties>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.0.8"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>30</daysToKeep>
@@ -16,7 +17,7 @@
       <projectUrl>https://github.com/kata-containers/tests/</projectUrl>
       <displayName></displayName>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.29">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.31">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -88,6 +89,16 @@ cd ${GOPATH}/src/${tests_repo}
 .ci/setup.sh
 .ci/install_bats.sh
 
+### Start KSM test ###
+
+make ksm
+
+### Start pentest ###
+
+make pentest
+
+## Start popular docker test ###
+
 cd ${GOPATH}/src/${tests_repo}/integration/popular_docker_hub_images/
 bats popular_docker_images.bats</command>
     </hudson.tasks.Shell>
@@ -131,10 +142,10 @@ cd $GOPATH/src/github.com/kata-containers/tests&#xd;
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.9"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.10"/>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.5.3">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.42"/>
+    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.47"/>
   </buildWrappers>
 </project>


### PR DESCRIPTION
This adds the config.xml for the jenkins job that runs the KSM test,
the pentesting and the docker popular images tests.

Fixes #209

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>