### PR TITLE
ci: Add and update jenkins jobs for the cache jobs

### DIFF
--- a/jenkins/jobs/kernel-nightly-x86_64/config.xml
+++ b/jenkins/jobs/kernel-nightly-x86_64/config.xml
@@ -4,19 +4,20 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.0.8"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>60</daysToKeep>
-        <numToKeep>3</numToKeep>
+        <numToKeep>8</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.29.3">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.29.4">
       <projectUrl>https://github.com/kata-containers/runtime/</projectUrl>
       <displayName></displayName>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
-    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.29">
+    <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.31">
       <autoRebuild>false</autoRebuild>
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
@@ -37,13 +38,13 @@
     <submoduleCfg class="list"/>
     <extensions/>
   </scm>
-  <assignedNode>ubuntu1804-azure</assignedNode>
+  <assignedNode>ubuntu-1804</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
-    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.29.3">
+    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.29.4">
       <spec></spec>
     </com.cloudbees.jenkins.GitHubPushTrigger>
   </triggers>
@@ -69,10 +70,10 @@ mkdir -p $(dirname &quot;${tests_repo_dir}&quot;)
 [ -d &quot;${tests_repo_dir}&quot; ] || git clone &quot;https://${tests_repo}.git&quot; &quot;${tests_repo_dir}&quot;
 ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p -f
 pushd ${tests_repo_dir}
-git checkout -b jcvenegas-user-kernel-cache master
-git pull https://github.com/jcvenegas/tests-1.git user-kernel-cache
+# git checkout -b jcvenegas-user-kernel-cache master
+# git pull https://github.com/jcvenegas/tests-1.git user-kernel-cache
 ./.ci/install_kata_kernel.sh
-./.ci/ci_cache_kernel.sh
+./.ci/ci_cache_components.sh -k
 popd
 </command>
     </hudson.tasks.Shell>
@@ -88,7 +89,7 @@ popd
     </hudson.tasks.ArtifactArchiver>
   </publishers>
   <buildWrappers>
-    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.17">
+    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.19">
       <bindings class="empty-list"/>
     </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.19">
@@ -97,10 +98,10 @@ popd
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.9"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.10"/>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.5.3">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.42"/>
+    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.47"/>
   </buildWrappers>
 </project>

--- a/jenkins/jobs/nemu-nightly-x86_64/config.xml
+++ b/jenkins/jobs/nemu-nightly-x86_64/config.xml
@@ -4,7 +4,7 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.0.7"/>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.0.8"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>60</daysToKeep>
@@ -44,6 +44,9 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>H 0-23/6 * * 1-5</spec>
+    </hudson.triggers.TimerTrigger>
     <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.29.4">
       <spec></spec>
     </com.cloudbees.jenkins.GitHubPushTrigger>
@@ -62,8 +65,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Export all environment variables needed.
 export GOROOT=&quot;/usr/local/go&quot;
-export GOPATH=$WORKSPACE/go
 export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
+export GOPATH=$WORKSPACE/go
 export tests_repo=&quot;${tests_repo:-github.com/kata-containers/tests}&quot;
 export tests_repo_dir=&quot;$GOPATH/src/$tests_repo&quot;
 
@@ -79,7 +82,8 @@ sed -i &apos;s/chronic //g&apos; ./.ci/setup_env_ubuntu.sh
 
 time ./.ci/setup_env_ubuntu.sh default
 ./.ci/install_nemu.sh
-./.ci/ci_cache_nemu.sh
+./.ci/ci_cache_components.sh -n
+
 sync
 popd</command>
     </hudson.tasks.Shell>
@@ -115,11 +119,11 @@ popd</command>
     </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.19">
       <strategy class="hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy">
-        <timeoutSecondsString>1200</timeoutSecondsString>
+        <timeoutSecondsString>1500</timeoutSecondsString>
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>
-    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.9"/>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.10"/>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.5.3">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>

--- a/jenkins/jobs/qemu-nightly-x86_64/config.xml
+++ b/jenkins/jobs/qemu-nightly-x86_64/config.xml
@@ -7,8 +7,8 @@
     <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.0.8"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>60</daysToKeep>
-        <numToKeep>10</numToKeep>
+        <daysToKeep>30</daysToKeep>
+        <numToKeep>5</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
@@ -45,7 +45,7 @@
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
     <hudson.triggers.TimerTrigger>
-      <spec>H 0-23/6 * * 1-5
+      <spec>H 0-23/12 * * 1-5
 </spec>
     </hudson.triggers.TimerTrigger>
     <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.29.4">
@@ -66,26 +66,21 @@ export PATH=${GOPATH}/bin:/usr/local/go/bin:/usr/sbin:/sbin:${PATH}
 export GOPATH=$WORKSPACE/go
 export tests_repo=&quot;${tests_repo:-github.com/kata-containers/tests}&quot;
 export tests_repo_dir=&quot;$GOPATH/src/$tests_repo&quot;
-
-sudo -E apt install -y libelf-dev bc gcc flex
-
+export DEBIAN_FRONTEND=noninteractive
 
 mkdir -p $(dirname &quot;${tests_repo_dir}&quot;)
 [ -d &quot;${tests_repo_dir}&quot; ] || git clone &quot;https://${tests_repo}.git&quot; &quot;${tests_repo_dir}&quot;
 ${GOPATH}/src/${tests_repo}/.ci/install_go.sh -p -f
 pushd ${tests_repo_dir}
 
-./.ci/install_kata_image.sh
-./.ci/ci_cache_components.sh -i
+.ci/setup_env_ubuntu.sh default
+./cmd/container-manager/manage_ctr_mgr.sh docker install -f
 
-export TEST_INITRD=yes
-export AGENT_INIT=yes
-./.ci/install_kata_image.sh
-./.ci/ci_cache_components.sh -r
+.ci/install_qemu.sh
+.ci/ci_cache_components.sh -q
 
-sync
 popd
-</command>
+sync</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
@@ -119,7 +114,7 @@ popd
     </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
     <hudson.plugins.build__timeout.BuildTimeoutWrapper plugin="build-timeout@1.19">
       <strategy class="hudson.plugins.build_timeout.impl.NoActivityTimeOutStrategy">
-        <timeoutSecondsString>900</timeoutSecondsString>
+        <timeoutSecondsString>1200</timeoutSecondsString>
       </strategy>
       <operationList/>
     </hudson.plugins.build__timeout.BuildTimeoutWrapper>


### PR DESCRIPTION
This adds the qemu cache jenkins job config as well as updates the
nemu, image and kernel cache jenkins jobs.

Fixes #214

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>