### PR TITLE
crio: Run the integration tests also for shimv2

### DIFF
--- a/jenkins/jobs/kata-containers-crio-PR/config.xml
+++ b/jenkins/jobs/kata-containers-crio-PR/config.xml
@@ -213,6 +213,14 @@ echo &quot;CRI-O Version to test:&quot;
 sudo crio --version
 crictl --version
 export RUNTIME=kata-runtime
+sudo -E PATH=$PATH make crio
+
+echo &quot;Ensure crio service is stopped before running the tests&quot;
+if systemctl is-active --quiet crio; then
+        sudo systemctl stop crio
+fi
+# Execute CRI-O tests using containerd-shim-kata-v2 runtime
+export RUNTIME=containerd-shim-kata-v2
 sudo -E PATH=$PATH make crio</command>
     </hudson.tasks.Shell>
   </builders>


### PR DESCRIPTION
Let's also run the integration tests with `containerd-shim-kata-v2` and
the VM runtime type.

Depends-on: github.com/kata-containers/tests/pull/2844
Fixes: github.com/kata-containers/tests#2842

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>