### PR TITLE
config,el8: Avoid conflicts when installing containerd

### DIFF
--- a/jenkins/config.xml
+++ b/jenkins/config.xml
@@ -1208,6 +1208,9 @@ sed -i &apos;s/#mirrorlist/mirrorlist/g&apos; /etc/yum.repos.d/CentOS-AppStream.
 yum -v clean all
 yum -y update
 
+# Ensure there's no podman or buildah installed, as docker will be used
+yum -y erase podman buildah
+
 # Install git, gcc and python
 yum install -y git gcc python3
 
@@ -1220,7 +1223,6 @@ yum -y install docker-ce
 systemctl start docker
 gpasswd -a jenkins docker
 chmod g+rw /var/run/docker.sock
-
 
 # Install Java JRE and JDK for Jenkins agent
 yum install -y java-1.8.0-openjdk
@@ -1554,6 +1556,9 @@ resize2fs /dev/rootvg/varlv
 df -h
 
 # yum -y update
+
+# Ensure there's no podman or buildah installed, as docker will be used
+yum -y erase podman buildah
 
 # Install git, gcc and python
 yum install -y git gcc python3


### PR DESCRIPTION
Currently we try to install a specific version of containers, from the
EL7 version of docker-ce.repo, while running an EL8 machine, which ends
up causing conflicts such as:
```
Error:
 Problem: package podman-1.9.3-2.module+el8.2.1+6867+366c07d6.x86_64 requires runc >= 1.0.0-57, but none of the providers can be installed
  - package containerd.io-1.2.6-3.3.el7.x86_64 conflicts with containerd provided by containerd.io-1.3.7-3.1.el8.x86_64
  - package containerd.io-1.3.7-3.1.el8.x86_64 conflicts with runc provided by containerd.io-1.2.6-3.3.el7.x86_64
  - package containerd.io-1.3.7-3.1.el8.x86_64 conflicts with containerd provided by containerd.io-1.2.6-3.3.el7.x86_64
  - cannot install both containerd.io-1.3.7-3.1.el8.x86_64 and containerd.io-1.2.6-3.3.el7.x86_64
```

In order to avoid such issue, let's rely solely on the containerd
distributed for the currently used version of the OS.

Fixes: #330

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>