### PR TITLE
jenkins: Clean up workspace in s390x tests job

### DIFF
--- a/jenkins/jobs/kata-containers-2.0-tests-ubuntu-s390x-PR/config.xml
+++ b/jenkins/jobs/kata-containers-2.0-tests-ubuntu-s390x-PR/config.xml
@@ -4,7 +4,7 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.3"/>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.5"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>30</daysToKeep>
@@ -13,7 +13,7 @@
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.33.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.34.1">
       <projectUrl>https://github.com/kata-containers/tests/</projectUrl>
       <displayName></displayName>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
@@ -22,7 +22,7 @@
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@4.7.2">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@4.8.2">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -111,6 +111,9 @@
 
 set -e
 
+shopt -s extglob
+sudo rm -rf $WORKSPACE/../!($(basename $WORKSPACE))
+
 export ghprbPullId
 export ghprbTargetBranch
 export GOPATH=&quot;${WORKSPACE}/go&quot;
@@ -187,6 +190,6 @@ sudo rm -rf ${WORKSPACE}_*</script>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@1.0.0">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.58"/>
+    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.60"/>
   </buildWrappers>
 </project>

--- a/jenkins/jobs/kata-containers-2.0-ubuntu-s390x-PR/config.xml
+++ b/jenkins/jobs/kata-containers-2.0-ubuntu-s390x-PR/config.xml
@@ -4,7 +4,7 @@
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
-    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.3"/>
+    <hudson.plugins.jira.JiraProjectProperty plugin="jira@3.5"/>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
         <daysToKeep>30</daysToKeep>
@@ -13,7 +13,7 @@
         <artifactNumToKeep>-1</artifactNumToKeep>
       </strategy>
     </jenkins.model.BuildDiscarderProperty>
-    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.33.1">
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.34.1">
       <projectUrl>https://github.com/kata-containers/kata-containers/</projectUrl>
       <displayName></displayName>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
@@ -22,7 +22,7 @@
       <rebuildDisabled>false</rebuildDisabled>
     </com.sonyericsson.rebuild.RebuildSettings>
   </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@4.7.2">
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@4.8.2">
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
@@ -111,6 +111,9 @@
 
 set -e
 
+shopt -s extglob
+sudo rm -rf $WORKSPACE/../!($(basename $WORKSPACE))
+
 export ghprbPullId
 export ghprbTargetBranch
 export DEBUG=true
@@ -196,6 +199,6 @@ sudo rm -rf /etc/docker</script>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@1.0.0">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.58"/>
+    <jenkins.plugins.openstack.compute.JCloudsOneOffSlave plugin="openstack-cloud@2.60"/>
   </buildWrappers>
 </project>


### PR DESCRIPTION
like we do in the main job, on ARM, and on Power, because the s390x test
instance does not quite have the disk space to keep tons of failed
tests. The list of branches was not edited by me.

Fixes: #392
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>