### PR TITLE
jobs-builder: add PR jobs for Fedora 35

### DIFF
--- a/jobs-builder/jobs/include/ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/ci_entrypoint.sh.inc
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wrapper shell script to call kata-containers/tests/.ci/ci_entry_point.sh
+# with expected environment variables exported.
+#
+
+set -e
+set -x
+
+curl -OL https://raw.githubusercontent.com/kata-containers/tests/main/.ci/ci_entry_point.sh
+export DEBUG=true
+export CI_JOB="{ci_job}"
+bash -x ci_entry_point.sh "$GIT_URL"

--- a/jobs-builder/jobs/include/os2node.yaml.inc
+++ b/jobs-builder/jobs/include/os2node.yaml.inc
@@ -6,7 +6,7 @@
 #}
 {%- if os == "centos8" -%}
 centos8_azure
-{%- elif os == "fedora35" -%}
+{%- elif os in ["fedora35", "fedora-35"] -%}
 fedora35_azure
 {%- elif os == "ubuntu1804" -%}
 ubuntu1804_azure || ubuntu1804-azure

--- a/jobs-builder/jobs/pr.yaml
+++ b/jobs-builder/jobs/pr.yaml
@@ -1,0 +1,180 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file contains the configurations to generate the pull request and
+# baseline jobs.
+#
+---
+###
+# Define shareable YAML snippets.
+###
+- main_jobs_common_properties: &main_jobs_common_properties
+    name: 'common_job_properties'
+    project-type: freestyle
+    disabled: false
+    concurrent: {concurrent_toggle}
+    logrotate:
+      daysToKeep: 30
+      numToKeep: 30
+    # Convert the os variable to label name.
+    node: !include-jinja2: include/os2node.yaml.inc
+    wrappers:
+      - ansicolor:
+          colormap: "xterm"
+      - openstack:
+          single-use: True
+      - timestamps
+      - timeout:
+          timeout: 20
+          type: no-activity
+- main_jobs_common_publishers: &main_jobs_common_publishers
+    name: 'default_publishers'
+    publishers:
+      - post-tasks:
+          - matches:
+              - log-text: .*
+                operator: OR
+            script: |
+              #!/bin/bash
+
+              export GOPATH=$WORKSPACE/go
+              export GOROOT="/usr/local/go"
+              export PATH="${{GOPATH}}/bin:/usr/local/go/bin:/usr/sbin:/usr/local/bin:${{PATH}}"
+
+              cd $GOPATH/src/github.com/kata-containers/tests
+              .ci/teardown.sh "$WORKSPACE/artifacts"
+      - archive:
+          artifacts: "artifacts/*"
+###
+# Define jobs templates.
+###
+- job-template:
+    # Use to generate baseline jobs.
+    #
+    # Arguments:
+    #   branch      - the repository branch.
+    #   os          - the node Operating System in <name>-<version> format.
+    #   arch        - the node architecture (e.g x86_64, s390x, ppc64le, and so on).
+    #   ci_job      - the CI job type as defined in https://github.com/kata-containers/tests/blob/main/.ci/ci_job_flags.sh
+    #   maintainers - a list of maintainer (use the github's mentions @somebody).
+    #
+    name: "kata-containers-{branch}-{os}-{arch}-{ci_job}-baseline"
+    <<: *main_jobs_common_properties
+    # Allow concurrent jobs by default. Specify `false` on the project definition otherwise.
+    concurrent_toggle: true
+    description:
+      !j2: |
+         <pre>
+         Baseline job.
+         /scheduled
+         status="Stable"
+         OS="{{ os }}"
+         arch="{{ arch }}"
+         CI_JOB="{{ ci_job }}"
+         repo="kata-containers"
+         type="baseline"
+         Maintainers:
+           {% for i in maintainers -%}
+           - {{ i }}
+           {% endfor %}
+         </pre>
+    scm:
+      - git:
+          url: https://github.com/kata-containers/kata-containers
+          branches:
+            - '*/{branch}'
+          wipe-workspace: false
+    triggers:
+      - timed: 'H 0 * * *'
+    builders:
+      - shell:
+          !include-raw: include/ci_entrypoint.sh.inc
+    <<: *main_jobs_common_publishers
+
+- job-template:
+    # Use to generate pull request (PR) jobs.
+    #
+    # Arguments:
+    #   repo        - the repository name.
+    #   os          - the node Operating System in <name>-<version> format.
+    #   arch        - the node architecture (e.g x86_64, s390x, ppc64le, and so on).
+    #   ci_job      - the CI job type as defined in https://github.com/kata-containers/tests/blob/main/.ci/ci_job_flags.sh
+    #
+    name: "{repo}-{os}-{arch}-{ci_job}-PR"
+    <<: *main_jobs_common_properties
+    # Allow concurrent jobs by default. Specify `false` on the project definition otherwise.
+    concurrent_toggle: true
+    description:
+      !j2: |
+         <pre>
+         Pull Request (PR) job.
+         OS="{{ os }}"
+         arch="{{ arch }}"
+         CI_JOB="{{ ci_job }}"
+         repo="{{ repo }}"
+         type="PR"
+         </pre>
+    scm:
+      - git:
+          url: https://github.com/kata-containers/{repo}
+          branches:
+            - '${{sha1}}'
+          refspec: '+refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*'
+          wipe-workspace: false
+    properties:
+      - github:
+          url: https://github.com/kata-containers/{repo}
+    triggers:
+      - github-pull-request:
+          auth-id: 'katacontainers'
+          github-hooks: true
+          # Trigger only on commenting phrase in the pull request.
+          only-trigger-phrase: true
+          # The expected phrase will be like "/(re)test-<OS Name>"
+          trigger-phrase:
+            !j2: '.*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(\n|$|\s)+.*'
+          # Skip on commenting phrase.
+          skip-build-phrase: '.*\[skip\W+ci\].*'
+          cron: 'H/5 * * * *'
+          # List of organizations whose members are allowed to build.
+          org-list:
+            - kata-containers
+          # Members of allowed organizations will have admin rights.
+          allow-whitelist-orgs-as-admins: true
+          # Branches allowed to be tested.
+          white-list-target-branches:
+            - main
+            - stable-2.*
+          # Branches disallowed to be tested.
+          black-list-target-branches:
+            - master
+            - stable-1.*
+    builders:
+      - shell:
+          !include-raw: include/ci_entrypoint.sh.inc
+    <<: *main_jobs_common_publishers
+
+###
+# Define the projects
+###
+- project:
+    name: "Generate jobs for CRIO_K8S"
+    repo:
+      - kata-containers
+      - tests
+    branch:
+      - main
+    os:
+      - fedora-35
+    arch:
+      - x86_64
+    ci_job:
+      - CRIO_K8S
+      - CRIO_K8S_MINIMAL
+    maintainers:
+      - '@snir911'
+      - '@c3d'
+    jobs:
+      - 'kata-containers-{branch}-{os}-{arch}-{ci_job}-baseline'
+      - '{repo}-{os}-{arch}-{ci_job}-PR'


### PR DESCRIPTION
This created the backbone to generate pull request and baseline jobs
with Jenkins Job Builder. Currently the yaml files are configured to
generate PR and baseline jobs for Fedora 35.

The following new jobs will be generated:

kata-containers-fedora-35-x86_64-CRIO_K8S-PR
kata-containers-fedora-35-x86_64-CRIO_K8S_MINIMAL-PR
kata-containers-main-fedora-35-x86_64-CRIO_K8S-baseline
kata-containers-main-fedora-35-x86_64-CRIO_K8S_MINIMAL-baseline
tests-fedora-35-x86_64-CRIO_K8S-PR
tests-fedora-35-x86_64-CRIO_K8S_MINIMAL-PR

Fixes #389
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>