### PR TITLE
github: add workflows for the jobs builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,19 @@ jobs:
         ci_repo=$(go env GOPATH)/src/github.com/kata-containers/ci
         pushd ${ci_repo}
         GOPATH=$(go env GOPATH) .ci/static-checks.sh
+  # Check that all jobs can be generated.
+  jobs-builder-check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install the Jenkins Job Builder
+        run: |
+          pip install --user jenkins-job-builder
+      - name: Check it can generate all jobs
+        run: |
+          cd jobs-builder
+          cp jjb.conf.template jjb.conf
+          ./publish_jobs.sh -c jjb.conf -t

--- a/.github/workflows/publish_jobs.yml
+++ b/.github/workflows/publish_jobs.yml
@@ -1,0 +1,34 @@
+# This workflow publishs all Jenkins jobs when a PR is merged.
+#
+---
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Run only when the definitions of jobs changed.
+      - 'jobs-builder/jobs/**'
+name: Publish Jenkins jobs
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install the Jenkins Job Builder
+        run: |
+          pip install --user jenkins-job-builder
+      - name: Run the publish script
+        env:
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          JENKINS_PASSWORD: ${{ secrets.JENKINS_PASSWORD }}
+        working-directory: jobs-builder
+        run: |
+          cp jjb.conf.template jjb.conf
+          if [[ -z "$JENKINS_USER" || -z "$JENKINS_PASSWORD" ]]; then
+              echo "ERROR: Missing the secrets JENKINS_USER and/or JENKINS_PASSWORD" >&2
+              exit 1
+          fi
+          sed -i -e "s/user=XXX/user=$JENKINS_USER/" \
+              -e "s/password=XXX/password=$JENKINS_PASSWORD/" jjb.conf
+          ./publish_jobs.sh -c jjb.conf

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ jenkins/credentials.xml
 # Include the Jenkins Job Builder files
 !jobs-builder
 !jobs-builder/**
+
+# Include the github workflow files
+!.github/workflows/*


### PR DESCRIPTION
It is added two new github workflows in this PR:

- On pull request, check that changes didn't break the jobs builder
- On push, automatically publish to Jenkins if any job configuration changed (it requires adding secrets on the configuration of this repository)

Fixes #343