### PR TITLE
jobs-builder: add trigger context on PR jobs

### DIFF
--- a/jobs-builder/jobs/pr.yaml
+++ b/jobs-builder/jobs/pr.yaml
@@ -150,6 +150,14 @@
           black-list-target-branches:
             - master
             - stable-1.*
+          cancel-builds-on-update: true
+          # Commit Status Context
+          status-context:
+            !j2: 'jenkins-ci-{{ os }}-{{ arch }}-{{ ci_job.lower() }}'
+          # Commit Status Build Triggered
+          triggered-status: Build triggered
+          # Commit Status Build Started
+          started-status: Build running
     builders:
       - shell:
           !include-raw: include/ci_entrypoint.sh.inc


### PR DESCRIPTION
This added more trigger configurations so that PR triggered jobs
will report to Github properly.

This will result on the following snippet being added on the `config.xml` of the jobs:
```XML
      <extensions>
        <org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
          <commitStatusContext>jenkins-ci-fedora-35-x86_64-crio_k8s</commitStatusContext>
          <triggeredStatus>Build triggered</triggeredStatus>
          <startedStatus>Build running</startedStatus>
          <statusUrl/>
          <addTestResults>false</addTestResults>
        </org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
        <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate/>
      </extensions>

```
Fixes #389
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>