### PR TITLE
github: remove uneeded workflow steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,22 +2,18 @@ on: ["pull_request"]
 name: Static checks
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
-        os: [ubuntu-18.04]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-20.04
     env:
       GO111MODULE: off
       TRAVIS: "true"
       TRAVIS_BRANCH: ${{ github.base_ref }}
       TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-      TRAVIS_PULL_REQUEST_SHA : ${{ github.event.pull_request.head.sha }}
+      TRAVIS_PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: "1.16"
     - name: Setup GOPATH
       run: |
         gopath_org=$(go env GOPATH)/src/github.com/kata-containers/
@@ -39,11 +35,6 @@ jobs:
         ci_repo=$(go env GOPATH)/src/github.com/kata-containers/ci
         pushd ${ci_repo}
         GOPATH=$(go env GOPATH) .ci/setup.sh
-    - name: Running tests
-      run: |
-        ci_repo=$(go env GOPATH)/src/github.com/kata-containers/ci
-        pushd ${ci_repo}
-        GOPATH=$(go env GOPATH) .ci/run.sh 
     - name: Running static checks
       run: |
         ci_repo=$(go env GOPATH)/src/github.com/kata-containers/ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,6 @@ jobs:
         go-version: "1.16"
     - name: Setup GOPATH
       run: |
-        gopath_org=$(go env GOPATH)/src/github.com/kata-containers/
-        mkdir -p ${gopath_org}
-        ln -s ${PWD} ${gopath_org}
         echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
         echo "TRAVIS_PULL_REQUEST_BRANCH: ${TRAVIS_PULL_REQUEST_BRANCH}"
         echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
@@ -27,6 +24,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        path: ${{ github.workspace }}/src/github.com/kata-containers/ci
+    - name: Set env
+      run: |
+        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Setup travis references
       run: |
         echo "TRAVIS_BRANCH=${TRAVIS_BRANCH:-$(echo $GITHUB_REF | awk 'BEGIN { FS = \"/\" } ; { print $3 }')}" 


### PR DESCRIPTION
Adding the following changes:

* This repository hasn't any golang code so it doesn't make sense to run
    the tests for many different golang versions. Also the 'Running tests' step
    is bogus as the called script (github.com/kata-containers/ci/tree/main/.ci/run.sh)
    just return `true`, thus it was removed.
* Allow to test on forked repos

Fixes #426 