### PR TITLE
jobs-builder: fix url in jjb.conf.template

### DIFF
--- a/jobs-builder/jjb.conf.template
+++ b/jobs-builder/jjb.conf.template
@@ -16,5 +16,5 @@ update=all
 [jenkins]
 user=XXX
 password=XXX
-url=https://jenkins.katacontainers.io
+url=http://jenkins.katacontainers.io
 query_plugins_info=False


### PR DESCRIPTION
It should not use HTTPS to connect to http://jenkins.katacontainers.io

Fixes #428
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>