### PR TITLE
jenkins: Enable power job to be triggered on /test

### DIFF
--- a/jenkins/jobs/kata-containers-2.0-Power9-containerd-k8s-ubuntu-20-04-PR/config.xml
+++ b/jenkins/jobs/kata-containers-2.0-Power9-containerd-k8s-ubuntu-20-04-PR/config.xml
@@ -77,7 +77,7 @@
         </org.jenkinsci.plugins.ghprb.GhprbBranch>
       </blackListTargetBranches>
       <gitHubAuthId>c217b635-ee39-4531-a4ed-db4048679d71</gitHubAuthId>
-      <triggerPhrase>.*(\n|^|\s)/(re)?test-power?(\n|$|\s)+.*</triggerPhrase>
+      <triggerPhrase>.*(\n|^|\s)/(re)?test(-power)?(\n|$|\s)+.*</triggerPhrase>
       <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
       <blackListCommitAuthor></blackListCommitAuthor>
       <blackListLabels></blackListLabels>


### PR DESCRIPTION
The Power job has been quite stable from the baseline runs.
Allow it to be run on /test.

Fixes: #438

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>