### PR TITLE
ci: add CentOS 8 Straem K8S jobs

### DIFF
--- a/jobs-builder/jobs/include/os2node.yaml.inc
+++ b/jobs-builder/jobs/include/os2node.yaml.inc
@@ -4,8 +4,8 @@
 #
 # Convert OS name to node label string.
 #}
-{%- if os == "centos8" -%}
-centos8_azure
+{%- if os == "centos-8-stream" -%}
+centos_8_stream
 {%- elif os in ["fedora35", "fedora-35"] -%}
 fedora35_azure
 {%- elif os == "ubuntu1804" -%}

--- a/jobs-builder/jobs/pr.yaml
+++ b/jobs-builder/jobs/pr.yaml
@@ -175,6 +175,7 @@
       - main
     os:
       - fedora-35
+      - centos-8-stream
     arch:
       - x86_64
     ci_job:


### PR DESCRIPTION
using jjb, also remove the centos8 node/label as it's not
deprecated

Baseline is passing for some time now
http://jenkins.katacontainers.io/view/Daily%20baseline/job/kata-containers-2.0-centos-8-stream-CRIO_K8S-main-baseline/

Fixes: #440
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>