### PR TITLE
jobs-builder: add jobs for CC_SKOPEO_CRI_CONTAINERD

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -134,5 +134,6 @@
       - x86_64
     ci_job:
       - CC_CRI_CONTAINERD
+      - CC_SKOPEO_CRI_CONTAINERD
     jobs:
       - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'


### PR DESCRIPTION
This added the following jobs which are triggered on pull requests
targeting the CCv0 branch:

kata-containers-CCv0-ubuntu-20.04-x86_64-CC_SKOPEO_CRI_CONTAINERD-PR
tests-CCv0-ubuntu-20.04-x86_64-CC_SKOPEO_CRI_CONTAINERD-PR

Fixes #451
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>

----
*Note:* this PR depends on https://github.com/kata-containers/tests/pull/4573