### PR TITLE
CCv1 | cc: Also test with Cloud Hypervisor

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -134,6 +134,8 @@
       - x86_64
     ci_job:
       - CC_CRI_CONTAINERD
+      - CC_CRI_CONTAINERD_CLOUD_HYPERVISOR
       - CC_SKOPEO_CRI_CONTAINERD
+      - CC_SKOPEO_CRI_CONTAINERD_CLOUD_HYPERVISOR
     jobs:
       - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'


### PR DESCRIPTION
The current tests with CC are using QEMU as the VMM.  Although right now
those are non-TEE specific, we better start testing against all the
supported VMMs sooner than later, this adding support to Cloud
Hypervisor here.

Fixes: #454

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>