### PR TITLE
Disable CentOS 8 Stream jobs

### DIFF
--- a/jobs-builder/jobs/pr.yaml
+++ b/jobs-builder/jobs/pr.yaml
@@ -12,7 +12,8 @@
 - main_jobs_common_properties: &main_jobs_common_properties
     name: 'common_job_properties'
     project-type: freestyle
-    disabled: false
+    disabled:
+      !j2: '{% if os == "centos-8-stream" -%}true{% else %}false{%- endif %}'
     concurrent: {concurrent_toggle}
     logrotate:
       daysToKeep: 30


### PR DESCRIPTION
This is going to disable the CentOS 8 Stream baseline job as well as
the jobs triggered on pull requests.

Fixes #458
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>