### PR TITLE
docs: Update url for contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).
+For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
This PR updates the url link for the contribution guide.

Fixes #467

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>