### PR TITLE
jobs-builder: add jobs for CC_SEV_CRI_CONTAINERD

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -207,6 +207,7 @@
       - ubuntu-20.04
     arch:
       - x86_64
+    baremetal: false
     ci_job:
       - CC_CRI_CONTAINERD
       - CC_CRI_CONTAINERD_CLOUD_HYPERVISOR

--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -117,7 +117,7 @@
           started-status: Build running
     builders:
       - shell:
-          !include-raw: include/cc-ci_entrypoint.sh.inc
+          !include-jinja2: include/cc-ci_entrypoint.sh.inc
     <<: *cc_jobs_common_publishers
 
 - job-template:

--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -207,7 +207,7 @@
       - ubuntu-20.04
     arch:
       - x86_64
-    baremetal: false
+    baremetal: "false"
     ci_job:
       - CC_CRI_CONTAINERD
       - CC_CRI_CONTAINERD_CLOUD_HYPERVISOR
@@ -229,3 +229,17 @@
       - kata-qemu
     jobs:
       - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-PR'
+- project:
+    name: "Generate jobs for Confidential Containers on AMD SEV"
+    repo:
+      - kata-containers
+      - tests
+    os:
+      - ubuntu-20.04_sev
+    arch:
+      - x86_64
+    baremetal: "true"
+    ci_job:
+      - CC_SEV_CRI_CONTAINERD_K8S
+    jobs:
+      - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'

--- a/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
@@ -12,7 +12,7 @@ set -e
 set -x
 
 curl -OL https://raw.githubusercontent.com/kata-containers/tests/CCv0/.ci/ci_entry_point.sh
-{% if baremetal -%}
+{% if baremetal == "true" -%}
 export BAREMETAL=true
 {% endif %}
 export DEBUG=true

--- a/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
@@ -3,14 +3,15 @@
 # Copyright (c) 2022 Red Hat, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Wrapper shell script to call kata-containers/tests/.ci/ci_entry_point.sh
-# with expected environment variables exported.
-#
+{# Wrapper shell script to call kata-containers/tests/.ci/ci_entry_point.sh
+   with expected environment variables exported.
+   This is a jinja2 template.
+#}
 
 set -e
 set -x
 
 curl -OL https://raw.githubusercontent.com/kata-containers/tests/CCv0/.ci/ci_entry_point.sh
 export DEBUG=true
-export CI_JOB="{ci_job}"
+export CI_JOB="{{ ci_job }}"
 bash -x ci_entry_point.sh "$GIT_URL"

--- a/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/cc-ci_entrypoint.sh.inc
@@ -12,6 +12,9 @@ set -e
 set -x
 
 curl -OL https://raw.githubusercontent.com/kata-containers/tests/CCv0/.ci/ci_entry_point.sh
+{% if baremetal -%}
+export BAREMETAL=true
+{% endif %}
 export DEBUG=true
 export CI_JOB="{{ ci_job }}"
 bash -x ci_entry_point.sh "$GIT_URL"

--- a/jobs-builder/jobs/include/os2node.yaml.inc
+++ b/jobs-builder/jobs/include/os2node.yaml.inc
@@ -12,6 +12,8 @@ fedora35_azure
 ubuntu1804_azure || ubuntu1804-azure
 {%- elif os == "ubuntu-20.04" -%}
 ubuntu_20.04
+{%- elif os == "ubuntu-20.04_sev" -%}
+amd-ubuntu-2004
 {%- elif os == "ubuntu-20.04-ARM" -%}
 arm_node || arm-ubuntu-2004
 {%- endif %}


### PR DESCRIPTION
This added the following jobs which are triggered on pull requests
targeting the CCv0 branch:

kata-containers-CCv0-ubuntu-20.04_sev-x86_64-CC_SEV_CRI_CONTAINERD_K8S
tests-CCv0-ubuntu-20.04_sev-x86_64-CC_SEV_CRI_CONTAINERD_K8S

Fixes #484 

Depends on https://github.com/kata-containers/tests/pull/4862