### PR TITLE
jobs-builder: delete workspace before build starts

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -28,6 +28,7 @@
       - timeout:
           timeout: 20
           type: no-activity
+      - workspace-cleanup
 - cc_jobs_common_publishers: &cc_jobs_common_publishers
     name: 'default_publishers'
     publishers:


### PR DESCRIPTION
Delete the workspace before the build is may be needed for jobs running on baremetal machine.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>