### PR TITLE
jobs-builder: add operator CI jobs for kata-clh

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -233,6 +233,7 @@
       - containerd
     runtimeclass:
       - kata-qemu
+      - kata-clh
     jobs:
       - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-PR'
 - project:


### PR DESCRIPTION
This add the following jobs which are triggered on pull requests for confidential-containers/operator:

confidential-containers-operator-main-ubuntu-20.04-x86_64-containerd_kata-clh-PR

Fixes #497
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>