### PR TITLE
jobs-builder: run SEV operator CI jobs on 'amd-ubuntu-2004_op-ci' nodes

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -223,7 +223,7 @@
     jobs:
       - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'
 - project:
-    name: "Generate jobs for the Confidential Container Operator"
+    name: "Generate jobs for the Confidential Containers Operator"
     os:
       - ubuntu-20.04
     arch:
@@ -237,7 +237,9 @@
     jobs:
       - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-PR'
 - project:
-    name: "Generate jobs for the Confidential Container Operator on AMD SEV"
+    # The node label is selected based on this project name. Be careful if you
+    # need to change the name.
+    name: "Generate jobs for the Confidential Containers Operator on AMD SEV"
     os:
       - ubuntu-20.04_sev
     arch:

--- a/jobs-builder/jobs/include/os2node.yaml.inc
+++ b/jobs-builder/jobs/include/os2node.yaml.inc
@@ -13,7 +13,8 @@ ubuntu1804_azure || ubuntu1804-azure
 {%- elif os == "ubuntu-20.04" -%}
 ubuntu_20.04
 {%- elif os == "ubuntu-20.04_sev" -%}
-amd-ubuntu-2004
+{# Run Kata and Operator CI jobs on different nodes. #}
+{{- "amd-ubuntu-2004_op-ci" if "Confidential Containers Operator" in name else "amd-ubuntu-2004" -}}
 {%- elif os == "ubuntu-20.04-ARM" -%}
 arm_node || arm-ubuntu-2004
 {%- endif %}


### PR DESCRIPTION
The AMD SEV jobs for the operator CI should run on a different node than those for Kata CI. This will make the operator CI SEV jobs to use the 'amd-ubuntu-2004_op-ci' labeled nodes (currently one in Jenkins pool).

The jobs/include/os2node.yaml.inc template uses the value of the project name to decide which label to pick. It is fragile. I tried to use the 'template-name' property to be more accurate, however, the hifen in 'template-name' makes that property inaccessible from a jinja2 template...

Fixes #495
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>