### PR TITLE
jobs-builder: enable CI for stable-2.3 branch of kata-containers

### DIFF
--- a/jobs-builder/jobs/pr.yaml
+++ b/jobs-builder/jobs/pr.yaml
@@ -147,6 +147,7 @@
           white-list-target-branches:
             - main
             - stable-2.*
+            - stable-3.*
           # Branches disallowed to be tested.
           black-list-target-branches:
             - master


### PR DESCRIPTION
Now that kata-containers 3.0.0 is about to be released, let's enable CI on the stable-2.3 branch.

Signed-off-by: Greg Kurz <groug@kaod.org>