### PR TITLE
jobs-builder: add mechanism to delete jobs

### DIFF
--- a/jobs-builder/README.md
+++ b/jobs-builder/README.md
@@ -39,6 +39,9 @@ them all then do:
 $ ./publish_jobs.sh -c jjb.conf -t
 ```
 
+The `publish_jobs.sh` can also delete unwanted and/or not needed anymore jobs. You
+just need to list their names in the `trash` file.
+
 Run `./publish_jobs.sh -h` to see all the available options of the script.
 
 # Checking your changes on a local Jenkins

--- a/jobs-builder/README.md
+++ b/jobs-builder/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-Manage the Jenkins jobs with help of the [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder) (JJB).
+Manage the Jenkins jobs with help of the [Jenkins Job Builder](https://jenkins-job-builder.readthedocs.io/en/latest/index.html) (JJB).
 
 The JJB converts jobs and views from YAML representations into the Jenkins XML
 configuration files. Also the tool is able to manage jobs, for example, publish
@@ -9,7 +9,7 @@ the generated jobs and views in a running Jenkins instance.
 # Getting started
 
 First of all, you need to install Jenkins Job Builder in your environment. The
-instructions can be found [here](https://docs.openstack.org/infra/jenkins-job-builder/installation.html).
+instructions can be found [here](https://jenkins-job-builder.readthedocs.io/en/latest/installation.html).
 
 To use the Jenkins Job Builder a configuration file is needed which contains
 the Jenkins URL, user and token API to manage Jenkins, among other information

--- a/jobs-builder/publish_jobs.sh
+++ b/jobs-builder/publish_jobs.sh
@@ -72,6 +72,12 @@ function main
 	if [ $test_only -eq 0 ]; then
 		# Going to update the managed jobs.
 		$cmd --conf "$config_file" update "$jobs_dir"
+
+		# Going to delete jobs.
+		jobs_to_delete=$(grep -v "^#" "${script_dir}/trash")
+		if [ -n "$jobs_to_delete" ]; then
+			$cmd --conf "$config_file" delete -j ${jobs_to_delete}
+		fi
 	fi
 }
 

--- a/jobs-builder/trash
+++ b/jobs-builder/trash
@@ -1,0 +1,9 @@
+# Copyright (c) 2023 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# List of jobs that should be deleted from Jenkins.
+#
+# Use to delete either unwanted generated jobs or jobs that no longer are needed.
+# The job can be removed from this list eventually if it is not generated anymore and it
+# was deleted at least one time.


### PR DESCRIPTION
After the jobs are published on Jenkins it might be desirable to also remove those not needed anymore or that were generated but not wanted. This added a way to delete the jobs as well.

Fixes #523
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>