### PR TITLE
jobs-builder: add credential binding for the quay.io registry

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -22,6 +22,10 @@
     wrappers:
       - ansicolor:
           colormap: "xterm"
+      - credentials-binding:
+          - text:
+              credential-id: quay_kata-containers-cc_auth_bot_creds
+              variable: REGISTRY_CREDENTIAL_ENCODED
       - openstack:
           single-use: True
       - timestamps


### PR DESCRIPTION
Some Kata tests read the authenticated image registry token from the REGISTRY_CREDENTIAL_ENCODED environment variable so that it should be exported on the build environment of all CCv0 jobs.

Fixes #525
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>