### PR TITLE
github: publish jobs if jobs-builder/trash changed

### DIFF
--- a/.github/workflows/publish_jobs.yml
+++ b/.github/workflows/publish_jobs.yml
@@ -8,6 +8,8 @@ on:
     paths:
       # Run only when the definitions of jobs changed.
       - 'jobs-builder/jobs/**'
+      # Or when the trash file changed.
+      - 'jobs-builder/trash'
 name: Publish Jenkins jobs
 jobs:
   publish:


### PR DESCRIPTION
The publish jobs action should be executed when the jobs-builder/trash file changes.

Fixes #523
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>