### PR TITLE
jobs-builder: allow to trigger only SEV jobs

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -67,6 +67,7 @@
     <<: *cc_jobs_common_properties
     # Allow concurrent jobs by default. Specify `false` on the project definition otherwise.
     concurrent_toggle: true
+    tee: ""
     description:
       !j2: |
          <pre>
@@ -95,7 +96,12 @@
           only-trigger-phrase: true
           # The expected phrase will be like "/(re)test-<OS Name>"
           trigger-phrase:
-            !j2: '.*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(\n|$|\s)+.*'
+            !j2: |
+              {% if not tee %}
+              .*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(\n|$|\s)+.*
+              {% else %}
+              .*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(-{{ tee }})?(\n|$|\s)+.*
+              {% endif %}
           # Skip on commenting phrase.
           skip-build-phrase: '.*\[skip\W+ci\].*'
           cron: 'H/5 * * * *'
@@ -262,6 +268,7 @@
     arch:
       - x86_64
     baremetal: "true"
+    tee: "sev"
     ci_job:
       - CC_SEV_CRI_CONTAINERD_K8S
     jobs:


### PR DESCRIPTION
Added a new variable (tee) to the confidential containers job template so that if export it will generate a trigger phrase to allow "/test-tee".

For example, the SEV jobs will have the trigger phrase:

.*(\n|^|\s)/(re)?test(-ubuntu)?(-sev)?(\n|$|\s)+.*

Allow for triggering the job with a simple "/test-sev".

Fixes #531
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>