### PR TITLE
jobs-builder: fix CC jobs triggers

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -97,11 +97,11 @@
           # The expected phrase will be like "/(re)test-<OS Name>"
           trigger-phrase:
             !j2: |
-              {% if not tee %}
+              {% if not tee -%}
               .*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(\n|$|\s)+.*
-              {% else %}
+              {%- else -%}
               .*(\n|^|\s)/(re)?test(-{{ os.split("-")[0] }})?(-{{ tee }})?(\n|$|\s)+.*
-              {% endif %}
+              {%- endif %}
           # Skip on commenting phrase.
           skip-build-phrase: '.*\[skip\W+ci\].*'
           cron: 'H/5 * * * *'


### PR DESCRIPTION
On commit e2005a9642a82c it was added a mechanism to trigger SEV jobs that actually broke all triggers of all CC jobs. The XML generated is like below (with line breaks):

```
<allowMembersOfWhitelistedOrgsAsAdmin>true</allowMembersOfWhitelistedOrgsAsAdmin>
      <triggerPhrase>
.*(\n|^|\s)/(re)?test(-ubuntu)?(-sev)?(\n|$|\s)+.*
</triggerPhrase>
      <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
      <onlyTriggerPhrase>true</onlyTriggerPhrase>
```

With this fix it will generate the XML correctly, trimming line breaks and spaces.

Fixes #531
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>