### PR TITLE
jobs-builder: increase timeout waiting images

### DIFF
--- a/jobs-builder/jobs/include/cc-ci.groovy
+++ b/jobs-builder/jobs/include/cc-ci.groovy
@@ -32,7 +32,7 @@ def operatorCommit = ""
 // The kata-containers repositories branch it should monitor
 def kataRepoBranch = "CCv0"
 // The amount of time in minutes it should wait for the images be built.
-def waitImagesTimeout = 30
+def waitImagesTimeout = 90
 
 // Keep polling the repositories for new changes.
 node("amd-ubuntu-2004_op-ci") {


### PR DESCRIPTION
The confidential-containers-ci job has a timeout to wait for the runtime-payload images to be built that is currently to small. Let's increase it to 90 minutes which is the time the images should be built on worst case.

Fixes #539
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>