### PR TITLE
Add baseline jobs for Confidential Containers

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -210,6 +210,49 @@
             export PATH="$PATH:/usr/local/bin"
             ./run-local.sh -r {{ runtimeclass }} {%+ if baremetal == "true" %}-u{% endif %}
 
+- job-template:
+    # Use to generate baseline jobs.
+    #
+    # Arguments:
+    #   os          - the node Operating System in <name>-<version> format.
+    #   arch        - the node architecture (e.g x86_64, s390x, ppc64le, and so on).
+    #   ci_job      - the CI job type as defined in https://github.com/kata-containers/tests/blob/main/.ci/ci_job_flags.sh
+    #   maintainers - a list of maintainer (use the github's mentions @somebody).
+    #
+    name: "kata-containers-CCv0-{os}-{arch}-{ci_job}-baseline"
+    <<: *cc_jobs_common_properties
+    # Allow concurrent jobs by default. Specify `false` on the project definition otherwise.
+    concurrent_toggle: true
+    description:
+      !j2: |
+         <pre>
+         Baseline job.
+         /scheduled
+         status="Stable"
+         OS="{{ os }}"
+         arch="{{ arch }}"
+         branch="CCv0"
+         CI_JOB="{{ ci_job }}"
+         repo="kata-containers"
+         type="baseline"
+         Maintainers:
+           {% for i in maintainers -%}
+           - {{ i }}
+           {% endfor %}
+         </pre>
+    scm:
+      - git:
+          url: https://github.com/kata-containers/kata-containers
+          branches:
+            - '*/CCv0'
+          wipe-workspace: false
+    triggers:
+      - timed: 'H 0 * * *'
+    builders:
+      - shell:
+          !include-jinja2: include/cc-ci_entrypoint.sh.inc
+    <<: *cc_jobs_common_publishers
+
 ###
 # Define the projects
 ###
@@ -227,8 +270,11 @@
       - CC_CRI_CONTAINERD
       - CC_CRI_CONTAINERD_CLOUD_HYPERVISOR
       - CC_CRI_CONTAINERD_K8S
+    maintainers:
+      - '@wainersm'
     jobs:
       - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'
+      - 'kata-containers-CCv0-{os}-{arch}-{ci_job}-baseline'
 - project:
     name: "Generate jobs for the Confidential Containers Operator"
     os:
@@ -271,8 +317,11 @@
     tee: "sev"
     ci_job:
       - CC_SEV_CRI_CONTAINERD_K8S
+    maintainers:
+      - '@ryansavino'
     jobs:
       - '{repo}-CCv0-{os}-{arch}-{ci_job}-PR'
+      - 'kata-containers-CCv0-{os}-{arch}-{ci_job}-baseline'
 
 ###
 # Define stand-alone jobs.
@@ -288,3 +337,10 @@
     triggers:
       - pollscm:
           cron: "@hourly"
+###
+# Define views.
+###
+- view:
+    name: Daily CCv0 baseline
+    view-type: list
+    regex: '.*-CCv0-.*-baseline'

--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -201,17 +201,10 @@
           started-status: Build running
     builders:
       - shell:
-          !j2: |
-            #!/bin/bash
-
-            sudo apt-get update -y
-            sudo apt-get install -y ansible python-is-python3
-            cd tests/e2e
-            export PATH="$PATH:/usr/local/bin"
-            ./run-local.sh -r {{ runtimeclass }} {%+ if baremetal == "true" %}-u{% endif %}
+          !include-jinja2: include/operator-ci_entrypoint.sh.inc
 
 - job-template:
-    # Use to generate baseline jobs.
+    # Use to generate baseline jobs for Kata Containers.
     #
     # Arguments:
     #   os          - the node Operating System in <name>-<version> format.
@@ -253,6 +246,48 @@
           !include-jinja2: include/cc-ci_entrypoint.sh.inc
     <<: *cc_jobs_common_publishers
 
+- job-template:
+    # Use to generate baseline jobs for the operator.
+    #
+    # Arguments:
+    #   os                - the node Operating System in <name>-<version> format.
+    #   arch              - the node architecture (e.g x86_64, s390x, ppc64le, and so on).
+    #   container_runtime - the container runtime (e.g. containerd, crio, and so on).
+    #   runtimeclass      - the kata runtimeclass (e.g. kata-qemu, kata-clh, and so on).
+    #   maintainers       - a list of maintainer (use the github's mentions @somebody).
+    #
+    name: "confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-baseline"
+    <<: *cc_jobs_common_properties
+    # Allow concurrent jobs by default. Specify `false` on the project definition otherwise.
+    concurrent_toggle: true
+    description:
+      !j2: |
+         <pre>
+         Baseline job.
+         /scheduled
+         status="Stable"
+         OS="{{ os }}"
+         arch="{{ arch }}"
+         branch="main"
+         repo="confidential-containers/operator"
+         type="baseline"
+         Maintainers:
+           {% for i in maintainers -%}
+           - {{ i }}
+           {% endfor %}
+         </pre>
+    scm:
+      - git:
+          url: https://github.com/confidential-containers/operator
+          branches:
+            - '*/main'
+          wipe-workspace: false
+    triggers:
+      - timed: 'H 0 * * *'
+    builders:
+      - shell:
+          !include-jinja2: include/operator-ci_entrypoint.sh.inc
+
 ###
 # Define the projects
 ###
@@ -287,8 +322,12 @@
     runtimeclass:
       - kata-qemu
       - kata-clh
+    maintainers:
+      - '@wainersm'
+      - '@fidencio'
     jobs:
       - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-PR'
+      - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-baseline'
 - project:
     # The node label is selected based on this project name. Be careful if you
     # need to change the name.
@@ -302,8 +341,11 @@
       - containerd
     runtimeclass:
       - kata-qemu-sev
+    maintainers:
+      - '@ryansavino'
     jobs:
       - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-PR'
+      - 'confidential-containers-operator-main-{os}-{arch}-{container_runtime}_{runtimeclass}-baseline'
 - project:
     name: "Generate jobs for Confidential Containers on AMD SEV"
     repo:
@@ -343,4 +385,4 @@
 - view:
     name: Daily CCv0 baseline
     view-type: list
-    regex: '.*-CCv0-.*-baseline'
+    regex: '.*\(operator-main\|CCv0\)-.*-baseline'

--- a/jobs-builder/jobs/include/operator-ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/operator-ci_entrypoint.sh.inc
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Red Hat, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+{# Run the Operator CI tests.
+   This is a jinja2 template.
+#}
+
+sudo apt-get update -y
+sudo apt-get install -y ansible python-is-python3
+cd tests/e2e
+export PATH="$PATH:/usr/local/bin"
+./run-local.sh -r "{{ runtimeclass }}" {%+ if baremetal == "true" %}-u{% endif %}
+


### PR DESCRIPTION
This will create jobs that run daily to "exercise" the stability of the CI jobs for Confidential Containers.

The following jobs will be generated:

  - confidential-containers-operator-main-ubuntu-20.04-x86_64-containerd_kata-clh-baseline
  - confidential-containers-operator-main-ubuntu-20.04-x86_64-containerd_kata-qemu-baseline
  - confidential-containers-operator-main-ubuntu-20.04_sev-x86_64-containerd_kata-qemu-sev-baseline
  - kata-containers-CCv0-ubuntu-20.04-x86_64-CC_CRI_CONTAINERD-baseline
  - kata-containers-CCv0-ubuntu-20.04-x86_64-CC_CRI_CONTAINERD_CLOUD_HYPERVISOR-baseline
  - kata-containers-CCv0-ubuntu-20.04-x86_64-CC_CRI_CONTAINERD_K8S-baseline
  - kata-containers-CCv0-ubuntu-20.04_sev-x86_64-CC_SEV_CRI_CONTAINERD_K8S-baseline

Fixes #542 