### PR TITLE
github: pin the jenkins-job version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install the Jenkins Job Builder
         run: |
           pip install --user --upgrade jinja2
-          pip install --user jenkins-job-builder
+          pip install --user jenkins-job-builder==4.3.0
       - name: Check it can generate all jobs
         run: |
           cd jobs-builder

--- a/.github/workflows/publish_jobs.yml
+++ b/.github/workflows/publish_jobs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install the Jenkins Job Builder
         run: |
           pip install --user --upgrade jinja2
-          pip install --user jenkins-job-builder
+          pip install --user jenkins-job-builder==4.3.0
       - name: Run the publish script
         env:
           JENKINS_USER: ${{ secrets.JENKINS_USER }}


### PR DESCRIPTION
The recently released jenkins-job version 5.0 fail to generate our jobs due to deprecated features removed. We can either fix our yaml files or keep using a known to work version of the tool. I chose the later option as Jenkins will be replaced with Github actions soon, so let's keep it simple. The last known working version of jenkins-job is 4.3.0.

Fixes #548
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>