### PR TITLE
job-builder: add CoCo operator jobs for Ubuntu 22.04

### DIFF
--- a/jobs-builder/jobs/cc.yaml
+++ b/jobs-builder/jobs/cc.yaml
@@ -314,6 +314,7 @@
     name: "Generate jobs for the Confidential Containers Operator"
     os:
       - ubuntu-20.04
+      - ubuntu-22.04
     arch:
       - x86_64
     baremetal: "false"

--- a/jobs-builder/jobs/include/operator-ci_entrypoint.sh.inc
+++ b/jobs-builder/jobs/include/operator-ci_entrypoint.sh.inc
@@ -9,6 +9,10 @@
 
 sudo apt-get update -y
 sudo apt-get install -y ansible python-is-python3
+# Ubuntu 22.04 comes with docker community edition that we don't want to
+# use.
+sudo apt-get remove -y docker-ce docker-ce-cli containerd.io || true
+sudo apt autoremove -y
 cd tests/e2e
 export PATH="$PATH:/usr/local/bin"
 ./run-local.sh -r "{{ runtimeclass }}" {%+ if baremetal == "true" %}-u{% endif %}

--- a/jobs-builder/jobs/include/os2node.yaml.inc
+++ b/jobs-builder/jobs/include/os2node.yaml.inc
@@ -12,6 +12,8 @@ fedora35_azure
 ubuntu1804_azure || ubuntu1804-azure
 {%- elif os == "ubuntu-20.04" -%}
 ubuntu_20.04
+{%- elif os == "ubuntu-22.04" -%}
+ubuntu22_04
 {%- elif os == "ubuntu-20.04_sev" -%}
 amd-ubuntu-2004
 {%- elif os == "ubuntu-20.04_snp" -%}


### PR DESCRIPTION
Run jobs on Ubuntu 22.04 with containerd 1.7, so we test the case here `INSTALL_OFFICIAL_CONTAINERD=false`, i.e., the operator will use the system's containerd.

Fixes #551
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>